### PR TITLE
タグ機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'bootstrap-sass', '~> 3.3.6'
 gem 'devise'
 gem 'carrierwave'
 gem 'kaminari'
+gem 'acts-as-taggable-on', '~> 4.0'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (4.0.0)
+      activerecord (>= 4.0)
     arel (6.0.3)
     autoprefixer-rails (6.4.0.3)
       execjs
@@ -204,6 +206,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 4.0)
   better_errors
   bootstrap-sass (~> 3.3.6)
   byebug

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -59,6 +59,6 @@ class PrototypesController < ApplicationController
 
 
   def prototype_params
-    params.require(:prototype).permit(:id, :title, :catch, :concept, photos_attributes: [:id, :prototype_id, :content, :status]).merge(user_id: current_user.id)
+    params.require(:prototype).permit(:id, :title, :catch, :concept, photos_attributes: [:id, :prototype_id, :content, :status]).merge(user_id: current_user.id, tag_list: params[:prototype][:tag])
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,5 @@
+class TagsController < ApplicationController
+  def index
+    @tags = ActsAsTaggableOn::Tag.most_used
+  end
+end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -2,4 +2,9 @@ class TagsController < ApplicationController
   def index
     @tags = ActsAsTaggableOn::Tag.most_used
   end
+
+  def show
+    @tag = ActsAsTaggableOn::Tag.find(params[:id])
+    @prototypes = Prototype.tagged_with(@tag.name).includes(:photos).order("created_at DESC")
+  end
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -4,7 +4,7 @@ class Prototype < ActiveRecord::Base
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy
   accepts_nested_attributes_for :photos, reject_if: proc { |attributes| attributes['content'].blank? }
-  acts_as_taggable_on :tag
+  acts_as_taggable
   validates :title, :catch, :concept, presence: true
 
   def liked_user?(user)

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -4,6 +4,7 @@ class Prototype < ActiveRecord::Base
   has_many :likes, dependent: :destroy
   has_many :comments, dependent: :destroy
   accepts_nested_attributes_for :photos, reject_if: proc { |attributes| attributes['content'].blank? }
+  acts_as_taggable_on :tag
   validates :title, :catch, :concept, presence: true
 
   def liked_user?(user)

--- a/app/views/prototypes/edit.html.haml
+++ b/app/views/prototypes/edit.html.haml
@@ -36,10 +36,10 @@
         %h4 Tag List
         .row
           .col-md-3
-            %input{type: "text", placeholder: "Web Design"}/
+            = text_field_tag "prototype[tag][]", "", placeholder: "Web Design", value: @prototype.tag.first
           .col-md-3
-            %input{type: "text", placeholder: "UI"}/
+            = text_field_tag "prototype[tag][]", "", placeholder: "UI", value: @prototype.tag.second
           .col-md-3
-            %input{type: "text", placeholder: "Application"}/
+            = text_field_tag "prototype[tag][]", "", placeholder: "Application", value: @prototype.tag.third
     .row.text-center.proto-btn
       = f.submit "Publish", class: "btn btn-lg btn-primary btn-block"

--- a/app/views/prototypes/edit.html.haml
+++ b/app/views/prototypes/edit.html.haml
@@ -36,10 +36,10 @@
         %h4 Tag List
         .row
           .col-md-3
-            = text_field_tag "prototype[tag][]", "", placeholder: "Web Design", value: @prototype.tag.first
+            = text_field_tag "prototype[tag][]", "", placeholder: "Web Design", value: @prototype.tags.first
           .col-md-3
-            = text_field_tag "prototype[tag][]", "", placeholder: "UI", value: @prototype.tag.second
+            = text_field_tag "prototype[tag][]", "", placeholder: "UI", value: @prototype.tags.second
           .col-md-3
-            = text_field_tag "prototype[tag][]", "", placeholder: "Application", value: @prototype.tag.third
+            = text_field_tag "prototype[tag][]", "", placeholder: "Application", value: @prototype.tags.third
     .row.text-center.proto-btn
       = f.submit "Publish", class: "btn btn-lg btn-primary btn-block"

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -27,8 +27,8 @@
                 .proto-posted
                   = p.created_at.strftime("%b %d")
               %ul.proto-tag-list.list-inline
-                - p.tag.each do |pt|
+                - p.tags.each do |prototypetag|
                   %li
-                    =link_to pt.name, tag_path(pt.id), class: "btn btn-default"
+                    =link_to prototypetag.name, tag_path(prototypetag.id), class: "btn btn-default"
 .text-center
   = paginate @prototype

--- a/app/views/prototypes/index.html.haml
+++ b/app/views/prototypes/index.html.haml
@@ -10,7 +10,7 @@
           = link_to "Popular PROTO", root_path
         %li{class: active?("prototypes/newest"), role: "presentation"}
           = link_to "Newest PROTO", prototypes_newest_index_path
-      %button{type: "button", class: "btn btn-default col-lg-1"} View Tags
+      = link_to "View Tags", tags_path, type: 'button', class: "btn btn-default col-lg-1"
 .container.proto-list
   .row
     - @prototype.each do |p|
@@ -27,9 +27,8 @@
                 .proto-posted
                   = p.created_at.strftime("%b %d")
               %ul.proto-tag-list.list-inline
-                %li
-                  = link_to "iPad", "#", class: "btn btn-default"
-                %li
-                  = link_to "wireframe", "#", class: "btn btn-default"
+                - p.tag.each do |pt|
+                  %li
+                    =link_to pt.name, tag_path(pt.id), class: "btn btn-default"
 .text-center
   = paginate @prototype

--- a/app/views/prototypes/new.html.haml
+++ b/app/views/prototypes/new.html.haml
@@ -33,10 +33,10 @@
         %h4 Tag List
         .row
           .col-md-3
-            %input{type: "text", placeholder: "Web Design"}/
+            = text_field_tag "prototype[tag][]", "", placeholder: "Web Design"
           .col-md-3
-            %input{type: "text", placeholder: "UI"}/
+            = text_field_tag "prototype[tag][]", "", placeholder: "UI"
           .col-md-3
-            %input{type: "text", placeholder: "Application"}/
+            = text_field_tag "prototype[tag][]", "", placeholder: "Application"
     .row.text-center.proto-btn
       = f.submit "Publish", class: "btn btn-lg btn-primary btn-block"

--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -34,9 +34,8 @@
     .col-md-3
       %h4 Tag List
       %ul.proto-tag-list.list-inline
-        %li
-          %a{href: "#", class: "btn btn-default"} iPad
-        %li
-          %a{href: "#", class: "btn btn-default"} wireframe
+        - @prototype.tag.each do |pt|
+          %li
+            =link_to pt.name, tag_path(pt.id), class: "btn btn-default"
   #comments
     = render partial: 'prototypes/comments/comment', locals: { prototype: @prototype, comments: @comments, comment: @comment}

--- a/app/views/prototypes/show.html.haml
+++ b/app/views/prototypes/show.html.haml
@@ -34,8 +34,8 @@
     .col-md-3
       %h4 Tag List
       %ul.proto-tag-list.list-inline
-        - @prototype.tag.each do |pt|
+        - @prototype.tags.each do |prototypetag|
           %li
-            =link_to pt.name, tag_path(pt.id), class: "btn btn-default"
+            =link_to prototypetag.name, tag_path(prototypetag.id), class: "btn btn-default"
   #comments
     = render partial: 'prototypes/comments/comment', locals: { prototype: @prototype, comments: @comments, comment: @comment}

--- a/app/views/tags/index.html.haml
+++ b/app/views/tags/index.html.haml
@@ -1,20 +1,10 @@
 .container
   .row
-    .col-sm-4.col-sm-3
-      %a.tag.thumbnail{href: "/tags/web"}
-        .tag-name
-          web
-        .tag-project
-          1 project
-    .col-sm-4.col-sm-3
-      %a.tag.thumbnail{href: "/tags/ios"}
-        .tag-name
-          iOS
-        .tag-project
-          1 project
-    .col-sm-4.col-sm-3
-      %a.tag.thumbnail{href: "/tags/design"}
-        .tag-name
-          Design
-        .tag-project
-          1 project
+    - @tags.each do |tag|
+      .col-sm-4.col-sm-3
+        = link_to tag_path(tag.id), class: "tag thumbnail" do
+          .tag-name
+            = tag.name
+          .tag-project
+            = "#{tag.taggings_count} project"
+

--- a/app/views/tags/index.html.haml
+++ b/app/views/tags/index.html.haml
@@ -1,0 +1,20 @@
+.container
+  .row
+    .col-sm-4.col-sm-3
+      %a.tag.thumbnail{href: "/tags/web"}
+        .tag-name
+          web
+        .tag-project
+          1 project
+    .col-sm-4.col-sm-3
+      %a.tag.thumbnail{href: "/tags/ios"}
+        .tag-name
+          iOS
+        .tag-project
+          1 project
+    .col-sm-4.col-sm-3
+      %a.tag.thumbnail{href: "/tags/design"}
+        .tag-name
+          Design
+        .tag-project
+          1 project

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -1,16 +1,18 @@
 .container
   .row
     .tag-header
-      %span # web
-    .col-sm-4.col-md-3.proto-content
-      .thumbnail
-        %a{href: "/prototypes/1"}
-          %img{alt: " ", src: "sample.png"}/
-        .caption
-          %h3
-            Salvation Army on iPad App Wireframe
-          .proto-meta
-            .proto-user
-              %a{href: "/users/1"} user
-            .proto-posted
-              Jun 28 Tue
+      %span
+        = "# #{@tag.name}"
+    - @prototypes.each do |p|
+      .col-sm-4.col-md-3.proto-content
+        .thumbnail
+          = link_to prototype_path(p) do
+            = image_tag p.photos.main.first.content
+          .caption
+            %h3
+              = p.title
+            .proto-meta
+              .proto-user
+                = link_to "by #{p.user.username}", user_path(p.user)
+              .proto-posted
+                = p.created_at.strftime("%b %d")

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -1,0 +1,16 @@
+.container
+  .row
+    .tag-header
+      %span # web
+    .col-sm-4.col-md-3.proto-content
+      .thumbnail
+        %a{href: "/prototypes/1"}
+          %img{alt: " ", src: "sample.png"}/
+        .caption
+          %h3
+            Salvation Army on iPad App Wireframe
+          .proto-meta
+            .proto-user
+              %a{href: "/users/1"} user
+            .proto-posted
+              Jun 28 Tue

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -24,29 +24,29 @@
               = @user.works
 .container.proto-list
   .row
-    - @prototypes.each do |p|
+    - @prototypes.each do |prototype|
       .col-sm-4.col-md-3.proto-content
         .dropdown.drop_menu_location
           = button_tag type: 'button', "aria-expanded": "true", "data-toggle": "dropdown", class: "btn btn-default dropdown-toggle", id: "dropdownMenu" do
             Action
           %ul.dropdown-menu{"aria-labelledby": "dropdownMenu1"}
             %li
-              = link_to "Delete", prototype_path(p), :method => :delete
+              = link_to "Delete", prototype_path(prototype), :method => :delete
             %li
-              = link_to "Edit", edit_prototype_path(p)
+              = link_to "Edit", edit_prototype_path(prototype)
         .thumbnail
-          = link_to prototype_path(p.id) do
-            = image_tag p.photos.main.first.content
+          = link_to prototype_path(prototype.id) do
+            = image_tag prototype.photos.main.first.content
             .caption
               %h3
-                = p.title
+                = prototype.title
               .proto-meta
                 .proto-user
                   = link_to "by #{@user.username}", user_path(@user.id)
                 .proto-posted
-                  = p.created_at.strftime("%b %d")
+                  = prototype.created_at.strftime("%b %d")
               %ul.proto-tag-list.list-inline
-                - p.tag.each do |tag|
+                - prototype.tags.each do |tag|
                   %li
                     = link_to "#{tag.name}", 'tag_path(tag.id)', class: 'btn btn-default'
 .text-center

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -46,9 +46,8 @@
                 .proto-posted
                   = p.created_at.strftime("%b %d")
               %ul.proto-tag-list.list-inline
-                %li
-                  = link_to "iPad", '', class: 'btn btn-default'
-                %li
-                  = link_to "wireframe", '', class: 'btn btn-default'
+                - p.tag.each do |tag|
+                  %li
+                    = link_to "#{tag.name}", 'tag_path(tag.id)', class: 'btn btn-default'
 .text-center
   = paginate @prototypes

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -26,7 +26,7 @@
   .row
     - @prototypes.each do |p|
       .col-sm-4.col-md-3.proto-content
-        .dropdown.drop_menu_location.open
+        .dropdown.drop_menu_location
           = button_tag type: 'button', "aria-expanded": "true", "data-toggle": "dropdown", class: "btn btn-default dropdown-toggle", id: "dropdownMenu" do
             Action
           %ul.dropdown-menu{"aria-labelledby": "dropdownMenu1"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
     resources :likes, only: [:create, :destroy], module: 'prototypes'
     resources :comments, only: :create, module: 'prototypes'
   end
+  resources :tags, only: [:index, :show, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,5 @@ Rails.application.routes.draw do
     resources :likes, only: [:create, :destroy], module: 'prototypes'
     resources :comments, only: :create, module: 'prototypes'
   end
-  resources :tags, only: [:index, :show, :update]
+  resources :tags, only: [:index, :show]
 end

--- a/db/migrate/20160929081054_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160929081054_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,31 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20160929081055_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160929081055_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,21 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20160929081056_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160929081056_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20160929081057_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160929081057_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20160929081058_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160929081058_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+class ChangeCollationForTagNames < ActiveRecord::Migration
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20160929081059_add_missing_indexes.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160929081059_add_missing_indexes.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+class AddMissingIndexes < ActiveRecord::Migration
+  def change
+    add_index :taggings, :tag_id
+    add_index :taggings, :taggable_id
+    add_index :taggings, :taggable_type
+    add_index :taggings, :tagger_id
+    add_index :taggings, :context
+
+    add_index :taggings, [:tagger_id, :tagger_type]
+    add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160923104403) do
+ActiveRecord::Schema.define(version: 20160929081059) do
 
   create_table "comments", force: :cascade do |t|
     t.datetime "created_at",                 null: false
@@ -48,6 +48,33 @@ ActiveRecord::Schema.define(version: 20160923104403) do
   end
 
   add_index "prototypes", ["user_id"], name: "index_prototypes_on_user_id", using: :btree
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer  "tag_id",        limit: 4
+    t.integer  "taggable_id",   limit: 4
+    t.string   "taggable_type", limit: 255
+    t.integer  "tagger_id",     limit: 4
+    t.string   "tagger_type",   limit: 255
+    t.string   "context",       limit: 128
+    t.datetime "created_at"
+  end
+
+  add_index "taggings", ["context"], name: "index_taggings_on_context", using: :btree
+  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+  add_index "taggings", ["tag_id"], name: "index_taggings_on_tag_id", using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy", using: :btree
+  add_index "taggings", ["taggable_id"], name: "index_taggings_on_taggable_id", using: :btree
+  add_index "taggings", ["taggable_type"], name: "index_taggings_on_taggable_type", using: :btree
+  add_index "taggings", ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type", using: :btree
+  add_index "taggings", ["tagger_id"], name: "index_taggings_on_tagger_id", using: :btree
+
+  create_table "tags", force: :cascade do |t|
+    t.string  "name",           limit: 255
+    t.integer "taggings_count", limit: 4,   default: 0
+  end
+
+  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  limit: 255,   default: "", null: false


### PR DESCRIPTION
# WHAT
- Protospace投稿時のタグ登録機能の実装
- タグ一覧機能の実装
- 各タグにおけるPrototype一覧機能の実装
# WHY

prototype間の共通事項を見付け、より細かな分類ごとに情報にアクセスできるようにする為
